### PR TITLE
changed key value in database reference

### DIFF
--- a/addons/godot-firebase/database/reference.gd
+++ b/addons/godot-firebase/database/reference.gd
@@ -83,7 +83,7 @@ func update(path : String, data : Dictionary) -> void:
 	
 	var to_update = JSON.print(data)
 	if pusher.get_http_client_status() != HTTPClient.STATUS_REQUESTING:
-		var resolved_path = (_get_list_url() + db_path + path + _get_remaining_path())
+		var resolved_path = (_get_list_url() + db_path + "/" + path + _get_remaining_path())
 		
 		pusher.request(resolved_path, PoolStringArray(), true, HTTPClient.METHOD_PATCH, to_update)
 	else:
@@ -149,5 +149,4 @@ func on_push_request_complete(result : int, response_code : int, headers : PoolS
 		emit_signal("push_failed")
 	
 	if push_queue.size() > 0:
-		push(push_queue[0])
-		push_queue.remove(0)
+		push(push_queue.pop_front())

--- a/addons/godot-firebase/database/resource.gd
+++ b/addons/godot-firebase/database/resource.gd
@@ -9,4 +9,4 @@ func _init(key : String, data : Dictionary) -> void:
 		self.data = data
 
 func _to_string():
-	return "{ key:{key}, data:{data}".format({key = key, data = data})
+	return "{ key:{key}, data:{data} }".format({key = key, data = data})

--- a/project.godot
+++ b/project.godot
@@ -104,20 +104,20 @@ enabled=PoolStringArray( "godot-firebase" )
 
 [firebase]
 
-environment_variables/apiKey="AIzaSyDU6T2yrMVEpjTPNZpqt5fHUjIyvUYtK4w"
-environment_variables/authDomain="fluted-gantry-245320.firebaseapp.com"
-environment_variables/databaseURL="https://fluted-gantry-245320.firebaseio.com"
-environment_variables/projectId="fluted-gantry-245320"
-environment_variables/storageBucket="fluted-gantry-245320.appspot.com"
-environment_variables/messagingSenderId="642802608856"
-environment_variables/appId="1:642802608856:web:1050141a83b3a2e78885ad"
-environment_variables/measurementId="G-72P3G0WHKG"
+environment_variables/apiKey=""
+environment_variables/authDomain=""
+environment_variables/databaseURL=""
+environment_variables/projectId=""
+environment_variables/storageBucket=""
+environment_variables/messagingSenderId=""
+environment_variables/appId=""
+environment_variables/measurementId=""
 environment_variables/googleId="340498762442-fo1ru5e6apibhbj1pq83gl4t0o81rhd5.apps.googleusercontent.com"
 environment_variables/googleSecret="8D0aTzsKQY8GfQVUe9P_GAk7"
 environment_variables/googleClientId="946834597046-ftp04p2ss4sf6s22h6kfdhc8ectr406s.apps.googleusercontent.com"
 environment_variables/googleClientSecret="VBxkzKXKXIu8PBrut4Go9ao4"
-environment_variables/clientId="642802608856-8h1ie43dmg3961bcjkfgjn1k2qij83a2.apps.googleusercontent.com"
-environment_variables/clientSecret="Spd6nr8n2x-UpfBDA6gdnHlY"
+environment_variables/clientId=""
+environment_variables/clientSecret=""
 
 [rendering]
 


### PR DESCRIPTION
This PR will change how `FirebaseResource` is structured as well as these changes will refelct in `FirebaseDatabaseReference`.

`FirebaseResource` now has a `key` value which is internally modified, removing the first `/` and returning just the document name.
This will let users have directly returned the document name without having the first trail simbol.
Since the path character is removed from the key, to the `update` function in `FirebaseDatabaseReference` will internally add it inside the request path, so that to update a document, the arguments will just be `update(resource.key, new_data)`