### PR TITLE
Add parsing of nested Dictionaries/Arrays

### DIFF
--- a/addons/godot-firebase/firestore/firestore_document.gd
+++ b/addons/godot-firebase/firestore/firestore_document.gd
@@ -21,9 +21,10 @@ func _init(doc : Dictionary = {}, _doc_name : String = "", _doc_fields : Diction
 
 # Pass a dictionary { 'key' : 'value' } to format it in a APIs usable .fields 
 static func dict2fields(dict : Dictionary) -> Dictionary:
-		var fields : Dictionary = dict
+		var fields : Dictionary = {}
 		var var_type : String = ""
 		for field in dict.keys():
+				var field_value = dict[field]
 				match typeof(dict[field]):
 						TYPE_NIL:
 								var_type = "nullValue"
@@ -37,9 +38,35 @@ static func dict2fields(dict : Dictionary) -> Dictionary:
 								var_type = "stringValue"
 						TYPE_ARRAY:
 								var_type = "arrayValue"
+								field_value = {"values": array2fields(field_value)}
 		
-				fields[field] = { var_type : dict[field] }
+				fields[field] = { var_type : field_value }
 		return {'fields' : fields}
+
+static func array2fields(array : Array) -> Array:
+		var fields : Array = array
+		var parsed_fields : Array = []
+		var var_type : String = ""
+		for field in fields:
+				if typeof(field) == TYPE_DICTIONARY:
+						parsed_fields.append({'mapValue': dict2fields(field) })
+						continue
+				match typeof(field):
+						TYPE_NIL:
+								var_type = "nullValue"
+						TYPE_BOOL:
+								var_type = "booleanValue"
+						TYPE_INT:
+								var_type = "integerValue"
+						TYPE_REAL:
+								var_type = "doubleValue"
+						TYPE_STRING:
+								var_type = "stringValue"
+						TYPE_ARRAY:
+								var_type = "arrayValue"
+						
+				parsed_fields.append({ var_type : field })
+		return parsed_fields
 
 # Pass the .fields inside a Firestore Document to print out the Dictionary { 'key' : 'value' }
 static func fields2dict(doc : Dictionary) -> Dictionary:

--- a/addons/godot-firebase/firestore/firestore_document.gd
+++ b/addons/godot-firebase/firestore/firestore_document.gd
@@ -44,12 +44,11 @@ static func dict2fields(dict : Dictionary) -> Dictionary:
 		return {'fields' : fields}
 
 static func array2fields(array : Array) -> Array:
-		var fields : Array = array
-		var parsed_fields : Array = []
+		var fields : Array = []
 		var var_type : String = ""
-		for field in fields:
+		for field in array:
 				if typeof(field) == TYPE_DICTIONARY:
-						parsed_fields.append({'mapValue': dict2fields(field) })
+						fields.append({'mapValue': dict2fields(field) })
 						continue
 				match typeof(field):
 						TYPE_NIL:
@@ -65,8 +64,8 @@ static func array2fields(array : Array) -> Array:
 						TYPE_ARRAY:
 								var_type = "arrayValue"
 						
-				parsed_fields.append({ var_type : field })
-		return parsed_fields
+				fields.append({ var_type : field })
+		return fields
 
 # Pass the .fields inside a Firestore Document to print out the Dictionary { 'key' : 'value' }
 static func fields2dict(doc : Dictionary) -> Dictionary:


### PR DESCRIPTION
- Add new array2fields function that formats Arrays for Firestore
  correctly.
- Change dict2fields function to use array2fields on Arrays.
- Both array2fields and dict2fields recursively call one another to
  parse the entire object.
- Return new object from dict2fields instead of modifying object passed
  in, so that calling it twice on the same object doesn't break it. 

This works with the following test object I was trying to save to firestore:

```
var islandData = {
    'ground': [
        {
            'x': 0,
            'y': 0
        },
        {
            'x': 1,
            'y': 0
        }
    ],
    'towers': [
        {
            'x': 0,
            'y': 0,
            'upgrades': []
        },
        {
            'x': 1,
            'y': 0,
            'upgrades': [
                {
                    'id': 'flamethrower',
                    'level': 2,
                    'attachpos': 'main'
                }
            ]
        }
    ]
}
```