### PR TITLE
Fix for hard crashes when trying to open file

### DIFF
--- a/addons/godot-firebase/auth/auth.gd
+++ b/addons/godot-firebase/auth/auth.gd
@@ -266,9 +266,12 @@ func _on_FirebaseAuth_request_completed(result : int, response_code : int, heade
 func save_auth(auth : Dictionary) -> void:
     if (OS.get_name() != 'HTML5' and OS.get_name() != 'UWP'):
         var encrypted_file = File.new()
-        encrypted_file.open_encrypted_with_pass("user://user.auth", File.WRITE, OS.get_unique_id())
-        encrypted_file.store_line(to_json(auth))
-        encrypted_file.close()
+        var err = encrypted_file.open_encrypted_with_pass("user://user.auth", File.WRITE, OS.get_unique_id())
+        if err != OK:
+            printerr("Error Opening File. Error Code: ", err)
+        else:
+            encrypted_file.store_line(to_json(auth))
+            encrypted_file.close()
     else:
         printerr("OS Not supported for saving auth data")
 
@@ -277,9 +280,12 @@ func save_auth(auth : Dictionary) -> void:
 func load_auth() -> void:
     if (OS.get_name() != 'HTML5' and OS.get_name() != 'UWP'):
         var encrypted_file = File.new()
-        encrypted_file.open_encrypted_with_pass("user://user.auth", File.READ, OS.get_unique_id())
-        var encrypted_file_data = parse_json(encrypted_file.get_line())
-        Firebase.Auth.manual_token_refresh(encrypted_file_data)
+        var err = encrypted_file.open_encrypted_with_pass("user://user.auth", File.READ, OS.get_unique_id())
+        if err != OK:
+            printerr("Error Opening File. Error Code: ", err)
+        else:
+            var encrypted_file_data = parse_json(encrypted_file.get_line())
+            Firebase.Auth.manual_token_refresh(encrypted_file_data)
     else:
         printerr("OS Not supported for loading auth data")
 


### PR DESCRIPTION
This will close #95 

The code now checks to make sure opening the file does not result in an error state. as long as var err == 0 or OK then everything will work. If not it will print out the error code to the console and continue along.

I checked this in my own project by saving a file with a password I set, and then opening it with a different one. Instead of crashing, the console printed "Error opening file. Error code: 16"