### PR TITLE
Remove space after Content-Type header

### DIFF
--- a/addons/godot-firebase/auth/auth.gd
+++ b/addons/godot-firebase/auth/auth.gd
@@ -162,7 +162,7 @@ func signup_with_email_and_password(email : String, password : String) -> void:
 func login_anonymous() -> void:
     if _is_ready():
         is_busy = true
-        request(_signup_request_url, ["Content-Type : application/json"], true, HTTPClient.METHOD_POST, JSON.print(_anonymous_login_request_body))
+        request(_signup_request_url, ["Content-Type: application/json"], true, HTTPClient.METHOD_POST, JSON.print(_anonymous_login_request_body))
 
 
 # Called with Firebase.Auth.login_with_email_and_password(email, password)


### PR DESCRIPTION
This was causing issues when exporting the application to HTML5. It was erroring out saying `"Content-Type " is not a valid header`. I guess because it does a split on the `:`