### PR TITLE
Add underscore before set_config in dynamic links

### DIFF
--- a/addons/godot-firebase/dynamiclinks/dynamiclinks.gd
+++ b/addons/godot-firebase/dynamiclinks/dynamiclinks.gd
@@ -30,7 +30,7 @@ enum REQUESTS {
     GENERATE
    }
 
-func set_config(config_json : Dictionary) -> void:
+func _set_config(config_json : Dictionary) -> void:
     _config = config_json
     _dynamic_link_request_url %= _config.apiKey
     _request_list_node = HTTPRequest.new()


### PR DESCRIPTION
In https://github.com/GodotNuts/GodotFirebase/commit/b617ce35a21c4e31946156607722e42819ccdad6 in #120 `DynamicLinks._set_config()` is called, but this function doesn't have an underscore before it, causing this plugin to crash upon launch. 

Added the underscore so it doesn't crash. 