### PR TITLE
Add Database and Firestore examples

### DIFF
--- a/addons/godot-firebase/firestore/firestore_collection.gd
+++ b/addons/godot-firebase/firestore/firestore_collection.gd
@@ -37,7 +37,7 @@ func get(documentId : String) -> FirestoreTask:
         add_child(firestore_task)
         firestore_task._set_action(FirestoreTask.TASK_GET)
         var url = _get_request_url() + _separator + documentId.replace(" ", "%20")
-        firestore_task.connect("add_document", self, "_on_add_document")
+        firestore_task.connect("get_document", self, "_on_get_document")
         firestore_task.connect("error", self, "_on_error")
         firestore_task._push_request(url, _authorization_header + auth.idtoken)
         return firestore_task
@@ -53,7 +53,7 @@ func add(documentId : String, fields : Dictionary = {}) -> FirestoreTask:
         firestore_task._set_action(FirestoreTask.TASK_POST)
         var url = _get_request_url() + _query_tag + _documentId_tag + documentId
         firestore_task._push_request(url, _authorization_header + auth.idtoken, JSON.print(FirestoreDocument.dict2fields(fields)))
-        firestore_task.connect("get_document", self, "_on_get_document")
+        firestore_task.connect("add_document", self, "_on_add_document")
         firestore_task.connect("error", self, "_on_error")
         return firestore_task
     else:

--- a/examples/database/database_host_game.gd
+++ b/examples/database/database_host_game.gd
@@ -1,0 +1,46 @@
+extends Node
+
+var db_ref : FirebaseDatabaseReference 
+
+signal authenticated()
+signal room_updated(info)
+
+func _ready():
+	Firebase.Auth.connect("signup_succeeded", self, "_create_game")
+	Firebase.Auth.connect("login_succeeded", self, "_create_game")
+	Firebase.Auth.connect("login_failed", self, "_on_auth_error")
+	Firebase.Auth.login_anonymous()
+
+func _create_room_code(length):
+	randomize()
+	var result           = ''	
+	var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+	var charactersLength = characters.length()
+	for _i in range(length):
+		result += characters[floor(rand_range(0, charactersLength))]
+	return result;
+
+func _create_game(auth_result : Dictionary):
+	emit_signal("authenticated")
+	var room_code = _create_room_code(4)
+		
+	var rooms_ref : FirebaseDatabaseReference = Firebase.Database.get_database_reference("/rooms/", {})
+	rooms_ref.connect("push_successful", self, "_connect_to_room", [room_code])
+	
+	rooms_ref.update(room_code, {
+		"code": room_code,
+	})
+	
+func _connect_to_room(room_code):
+	db_ref = Firebase.Database.get_database_reference("/rooms/" + room_code, {})
+	db_ref.connect("new_data_update", self, "_updated_data")
+	db_ref.connect("patch_data_update", self, "_updated_data")
+	db_ref.connect("push_successful", self, "_push_successful")
+	db_ref.connect("push_failed", self, "_push_failed")
+
+func _updated_data(data):
+	var info = db_ref.get_data()
+	emit_signal("room_updated", info)
+	
+func _on_auth_error(code, msg):
+	print("Authentication errror encountered. Code: ", code, " MSG: ", msg)

--- a/examples/database/database_host_game.gd
+++ b/examples/database/database_host_game.gd
@@ -6,41 +6,39 @@ signal authenticated()
 signal room_updated(info)
 
 func _ready():
-	Firebase.Auth.connect("signup_succeeded", self, "_create_game")
-	Firebase.Auth.connect("login_succeeded", self, "_create_game")
-	Firebase.Auth.connect("login_failed", self, "_on_auth_error")
-	Firebase.Auth.login_anonymous()
+    Firebase.Auth.connect("signup_succeeded", self, "_create_game")
+    Firebase.Auth.connect("login_succeeded", self, "_create_game")
+    Firebase.Auth.connect("login_failed", self, "_on_auth_error")
+    Firebase.Auth.login_anonymous()
 
 func _create_room_code(length):
-	randomize()
-	var result           = ''	
-	var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-	var charactersLength = characters.length()
-	for _i in range(length):
-		result += characters[floor(rand_range(0, charactersLength))]
-	return result;
+    randomize()
+    var result           = ''	
+    var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    var charactersLength = characters.length()
+    for _i in range(length):
+        result += characters[floor(rand_range(0, charactersLength))]
+    return result;
 
 func _create_game(auth_result : Dictionary):
-	emit_signal("authenticated")
-	var room_code = _create_room_code(4)
-		
-	var rooms_ref : FirebaseDatabaseReference = Firebase.Database.get_database_reference("/rooms/", {})
-	rooms_ref.connect("push_successful", self, "_connect_to_room", [room_code])
-	
-	rooms_ref.update(room_code, {
-		"code": room_code,
-	})
-	
+    emit_signal("authenticated")
+    var room_code = _create_room_code(4)
+        
+    var rooms_ref : FirebaseDatabaseReference = Firebase.Database.get_database_reference("/rooms/", {})
+    rooms_ref.connect("push_successful", self, "_connect_to_room", [room_code])
+    
+    rooms_ref.update(room_code, {
+        "code": room_code,
+    })
+    
 func _connect_to_room(room_code):
-	db_ref = Firebase.Database.get_database_reference("/rooms/" + room_code, {})
-	db_ref.connect("new_data_update", self, "_updated_data")
-	db_ref.connect("patch_data_update", self, "_updated_data")
-	db_ref.connect("push_successful", self, "_push_successful")
-	db_ref.connect("push_failed", self, "_push_failed")
+    db_ref = Firebase.Database.get_database_reference("/rooms/" + room_code, {})
+    db_ref.connect("new_data_update", self, "_updated_data")
+    db_ref.connect("patch_data_update", self, "_updated_data")
 
 func _updated_data(data):
-	var info = db_ref.get_data()
-	emit_signal("room_updated", info)
-	
+    var info = db_ref.get_data()
+    emit_signal("room_updated", info)
+    
 func _on_auth_error(code, msg):
-	print("Authentication errror encountered. Code: ", code, " MSG: ", msg)
+    print("Authentication errror encountered. Code: ", code, " MSG: ", msg)

--- a/examples/database/database_host_game.tscn
+++ b/examples/database/database_host_game.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://examples/database/database_host_game.gd" type="Script" id=1]
+
+[node name="database_host_game" type="Node2D"]
+script = ExtResource( 1 )

--- a/examples/firestore/firestore_host_game.gd
+++ b/examples/firestore/firestore_host_game.gd
@@ -1,0 +1,55 @@
+extends Node
+
+var ROOMS_DATABASE = "rooms"
+
+var collection
+var room_code
+
+onready var timer = $Timer
+
+signal authenticated()
+signal room_updated(info)
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	Firebase.Auth.connect("signup_succeeded", self, "_create_game")
+	Firebase.Auth.connect("login_succeeded", self, "_create_game")
+	Firebase.Auth.connect("login_failed", self, "_on_auth_error")
+	Firebase.Auth.login_anonymous()
+
+func _create_room_code(length):
+	randomize()
+	var result           = ''	
+	var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+	var charactersLength = characters.length()
+	for _i in range(length):
+		result += characters[floor(rand_range(0, charactersLength))]
+	return result;
+
+func _create_game(auth_result : Dictionary):
+	emit_signal("authenticated")
+	
+	collection = Firebase.Firestore.collection(ROOMS_DATABASE)
+	collection.connect("error", self, "_on_network_error")
+	
+	room_code = _create_room_code(4)
+	var room_information = {
+		"code": room_code,
+		"players": []
+	}
+	collection.add(room_code, room_information)
+	var document : FirestoreDocument = yield(collection, "add_document")	
+	
+	timer.start()
+
+func _on_auth_error(code, msg):
+	print("Authentication errror encountered. Code: ", code, " MSG: ", msg)
+
+func _on_network_error(code, status, msg):
+	print("Network error encountered. Code: ", code, " Status: ", status, " MSG: ", msg)
+
+func _on_Timer_timeout():
+	collection.get(room_code)
+	var document : FirestoreDocument = yield(collection, "get_document")
+	var room_information = document['doc_fields']
+	emit_signal("room_updated", room_information)

--- a/examples/firestore/firestore_host_game.gd
+++ b/examples/firestore/firestore_host_game.gd
@@ -37,13 +37,15 @@ func _create_game(auth_result : Dictionary):
         "code": room_code,
         "players": []
     }
+
     collection.add(room_code, room_information)
     var document : FirestoreDocument = yield(collection, "add_document")	
+    print("Created room of code: ", room_code)
     
     timer.start()
 
 func _on_auth_error(code, msg):
-    print("Authentication errror encountered. Code: ", code, " MSG: ", msg)
+    print("Authentication error encountered. Code: ", code, " MSG: ", msg)
 
 func _on_network_error(code, status, msg):
     print("Network error encountered. Code: ", code, " Status: ", status, " MSG: ", msg)

--- a/examples/firestore/firestore_host_game.gd
+++ b/examples/firestore/firestore_host_game.gd
@@ -12,44 +12,44 @@ signal room_updated(info)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	Firebase.Auth.connect("signup_succeeded", self, "_create_game")
-	Firebase.Auth.connect("login_succeeded", self, "_create_game")
-	Firebase.Auth.connect("login_failed", self, "_on_auth_error")
-	Firebase.Auth.login_anonymous()
+    Firebase.Auth.connect("signup_succeeded", self, "_create_game")
+    Firebase.Auth.connect("login_succeeded", self, "_create_game")
+    Firebase.Auth.connect("login_failed", self, "_on_auth_error")
+    Firebase.Auth.login_anonymous()
 
 func _create_room_code(length):
-	randomize()
-	var result           = ''	
-	var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-	var charactersLength = characters.length()
-	for _i in range(length):
-		result += characters[floor(rand_range(0, charactersLength))]
-	return result;
+    randomize()
+    var result           = ''	
+    var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    var charactersLength = characters.length()
+    for _i in range(length):
+        result += characters[floor(rand_range(0, charactersLength))]
+    return result;
 
 func _create_game(auth_result : Dictionary):
-	emit_signal("authenticated")
-	
-	collection = Firebase.Firestore.collection(ROOMS_DATABASE)
-	collection.connect("error", self, "_on_network_error")
-	
-	room_code = _create_room_code(4)
-	var room_information = {
-		"code": room_code,
-		"players": []
-	}
-	collection.add(room_code, room_information)
-	var document : FirestoreDocument = yield(collection, "add_document")	
-	
-	timer.start()
+    emit_signal("authenticated")
+    
+    collection = Firebase.Firestore.collection(ROOMS_DATABASE)
+    collection.connect("error", self, "_on_network_error")
+    
+    room_code = _create_room_code(4)
+    var room_information = {
+        "code": room_code,
+        "players": []
+    }
+    collection.add(room_code, room_information)
+    var document : FirestoreDocument = yield(collection, "add_document")	
+    
+    timer.start()
 
 func _on_auth_error(code, msg):
-	print("Authentication errror encountered. Code: ", code, " MSG: ", msg)
+    print("Authentication errror encountered. Code: ", code, " MSG: ", msg)
 
 func _on_network_error(code, status, msg):
-	print("Network error encountered. Code: ", code, " Status: ", status, " MSG: ", msg)
+    print("Network error encountered. Code: ", code, " Status: ", status, " MSG: ", msg)
 
 func _on_Timer_timeout():
-	collection.get(room_code)
-	var document : FirestoreDocument = yield(collection, "get_document")
-	var room_information = document['doc_fields']
-	emit_signal("room_updated", room_information)
+    collection.get(room_code)
+    var document : FirestoreDocument = yield(collection, "get_document")
+    var room_information = document['doc_fields']
+    emit_signal("room_updated", room_information)

--- a/examples/firestore/firestore_host_game.tscn
+++ b/examples/firestore/firestore_host_game.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://examples/firestore/firestore_host_game.gd" type="Script" id=1]
+
+[node name="firestore_host_game" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="Timer" type="Timer" parent="."]


### PR DESCRIPTION
- Add Realtime Database host game example that creates a game in `/rooms` with a room code, and then listens for updates. 
- Add Firestore host game example that creates a game in `rooms` collection in Firestore, then polls for updates on 1s interval (as there is currently no way to listen for updates with Firestore). The `rooms` collection needs to be created first or it crashes with an Authentication Error (this should also be handled gracefully). 

These are examples to demonstrate #126 

Both these examples should be working but aren't since the refactoring today. I'd like to add these so they can be used as test cases to test against when releasing new changes to GodotFirebase. As well as a demo for new users to get started with the plugin. 
 