### PR TITLE
Fix Firestore Deserialization of Arrays

### DIFF
--- a/addons/godot-firebase/firestore/firestore_document.gd
+++ b/addons/godot-firebase/firestore/firestore_document.gd
@@ -21,7 +21,7 @@ func _init(doc : Dictionary = {}, _doc_name : String = "", _doc_fields : Diction
     self.doc_name = doc.name
     if self.doc_name.count("/") > 2:
         self.doc_name = (self.doc_name.split("/") as Array).back()
-    self.doc_fields = fields2dict(document)
+    self.doc_fields = fields2dict(self.document)
     self.create_time = doc.createTime
 
 # Pass a dictionary { 'key' : 'value' } to format it in a APIs usable .fields 
@@ -69,7 +69,22 @@ static func fields2array(array : Dictionary) -> Array:
     var fields : Array = []
     if array.has("values"):
         for field in array.values:
-            fields.append(field.values()[0])
+            var item
+            if field.has("mapValue"):
+                item = fields2dict(field.mapValue)
+            elif field.has("arrayValue"):
+                item = fields2array(field.arrayValue)
+            elif field.has("integerValue"):
+                item = field.values()[0] as int
+            elif field.has("doubleValue"):
+                item = field.values()[0] as float
+            elif field.has("booleanValue"):
+                item = field.values()[0] as bool
+            elif field.has("nullValue"):
+                item = null
+            else:
+                item = field.values()[0]
+            fields.append(item)
     return fields
 
 # Pass the .fields inside a Firestore Document to print out the Dictionary { 'key' : 'value' }

--- a/addons/godot-firebase/firestore/firestore_document.gd
+++ b/addons/godot-firebase/firestore/firestore_document.gd
@@ -70,20 +70,21 @@ static func fields2array(array : Dictionary) -> Array:
     if array.has("values"):
         for field in array.values:
             var item
-            if field.has("mapValue"):
-                item = fields2dict(field.mapValue)
-            elif field.has("arrayValue"):
-                item = fields2array(field.arrayValue)
-            elif field.has("integerValue"):
-                item = field.values()[0] as int
-            elif field.has("doubleValue"):
-                item = field.values()[0] as float
-            elif field.has("booleanValue"):
-                item = field.values()[0] as bool
-            elif field.has("nullValue"):
-                item = null
-            else:
-                item = field.values()[0]
+            match field.keys()[0]:
+                "mapValue":
+                    item = fields2dict(field.mapValue)
+                "arrayValue":
+                    item = fields2array(field.arrayValue)
+                "integerValue":
+                    item = field.values()[0] as int
+                "doubleValue":
+                    item = field.values()[0] as float
+                "booleanValue":
+                    item = field.values()[0] as bool
+                "nullValue":
+                    item = null
+                _:
+                    item = field.values()[0]
             fields.append(item)
     return fields
 

--- a/test/unit/test_FirebaseDatabaseStore.gd
+++ b/test/unit/test_FirebaseDatabaseStore.gd
@@ -3,206 +3,206 @@ extends "res://addons/gut/test.gd"
 const FirebaseDatabaseStore = preload("res://addons/godot-firebase/database/database_store.gd")
 const TestKey = "-MPrgu_F8OXiL-VpRxjq"
 const TestObject = {
-	"I": "Some Value",
-	"II": "Some Other Value",
-	"III": [111, 222, 333, 444, 555],
-	"IV": {
-		"a": "Another Value",
-		"b": "Yet Another Value"
-	}
+    "I": "Some Value",
+    "II": "Some Other Value",
+    "III": [111, 222, 333, 444, 555],
+    "IV": {
+        "a": "Another Value",
+        "b": "Yet Another Value"
+    }
 }
 const TestObjectOther = {
-	"a": "A Different Value",
-	"b": "Another One",
-	"c": "A New Value"
+    "a": "A Different Value",
+    "b": "Another One",
+    "c": "A New Value"
 }
 const TestArray = [666, 777, 888, 999]
 const TestValue = 12345.6789
 
 class TestPutOperations:
-	extends "res://addons/gut/test.gd"
-	
-	func test_put_object():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]
-		
-		assert_eq_deep(store_object, TestObject)
-		
-		store.queue_free()
-	
-	func test_put_nested_object():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		store.put(TestKey + "/V", TestObjectOther)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["V"]
-		
-		assert_eq_deep(store_object, TestObjectOther)
-		
-		store.queue_free()
-	
-	func test_put_array_value():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		store.put(TestKey + "/III", TestArray)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["III"]
-		
-		assert_eq_deep(store_object, TestArray)
-		
-		store.queue_free()
-	
-	func test_put_normal_value():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		store.put(TestKey + "/II", TestValue)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["II"]
-		
-		assert_eq_deep(store_object, TestValue)
-		
-		store.queue_free()
-	
-	func test_put_deleted_value():
-		# NOTE: Firebase Realtime Database sets values to null to indicate that they have been
-		#  deleted.
-		
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		store.put(TestKey + "/II", null)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]
-		
-		assert_false(store_object.has("II"), "The value should have been deleted, but was not.")
-		
-		store.queue_free()
-	
-	func test_put_new_object():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]
-		
-		assert_eq_deep(store_object, TestObject)
-		
-		store.queue_free()
-	
-	func test_put_new_nested_object():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey + "/V", TestObjectOther)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["V"]
-		
-		assert_eq_deep(store_object, TestObjectOther)
-		
-		store.queue_free()
-	
-	func test_put_new_array_value():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey + "/III", TestArray)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["III"]
-		
-		assert_eq_deep(store_object, TestArray)
-		
-		store.queue_free()
-	
-	func test_put_new_normal_value():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey + "/II", TestValue)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["II"]
-		
-		assert_eq_deep(store_object, TestValue)
-		
-		store.queue_free()
+    extends "res://addons/gut/test.gd"
+    
+    func test_put_object():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]
+        
+        assert_eq_deep(store_object, TestObject)
+        
+        store.queue_free()
+    
+    func test_put_nested_object():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        store.put(TestKey + "/V", TestObjectOther)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["V"]
+        
+        assert_eq_deep(store_object, TestObjectOther)
+        
+        store.queue_free()
+    
+    func test_put_array_value():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        store.put(TestKey + "/III", TestArray)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["III"]
+        
+        assert_eq_deep(store_object, TestArray)
+        
+        store.queue_free()
+    
+    func test_put_normal_value():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        store.put(TestKey + "/II", TestValue)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["II"]
+        
+        assert_eq_deep(store_object, TestValue)
+        
+        store.queue_free()
+    
+    func test_put_deleted_value():
+        # NOTE: Firebase Realtime Database sets values to null to indicate that they have been
+        #  deleted.
+        
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        store.put(TestKey + "/II", null)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]
+        
+        assert_false(store_object.has("II"), "The value should have been deleted, but was not.")
+        
+        store.queue_free()
+    
+    func test_put_new_object():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]
+        
+        assert_eq_deep(store_object, TestObject)
+        
+        store.queue_free()
+    
+    func test_put_new_nested_object():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey + "/V", TestObjectOther)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["V"]
+        
+        assert_eq_deep(store_object, TestObjectOther)
+        
+        store.queue_free()
+    
+    func test_put_new_array_value():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey + "/III", TestArray)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["III"]
+        
+        assert_eq_deep(store_object, TestArray)
+        
+        store.queue_free()
+    
+    func test_put_new_normal_value():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey + "/II", TestValue)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["II"]
+        
+        assert_eq_deep(store_object, TestValue)
+        
+        store.queue_free()
 
 class TestPatchOperations:
-	extends "res://addons/gut/test.gd"
-	
-	func test_patch_object():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.patch(TestKey, TestObject)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]
-		
-		assert_eq_deep(store_object, TestObject)
-		
-		store.queue_free()
-	
-	func test_patch_nested_object():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		store.patch(TestKey + "/V", TestObjectOther)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["V"]
-		
-		assert_eq_deep(store_object, TestObjectOther)
-		
-		store.queue_free()
-	
-	func test_patch_array_value():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		store.patch(TestKey + "/III", TestArray)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["III"]
-		
-		assert_eq_deep(store_object, TestArray)
-		
-		store.queue_free()
-	
-	func test_patch_normal_value():
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		store.patch(TestKey + "/II", TestValue)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]["II"]
-		
-		assert_eq_deep(store_object, TestValue)
-		
-		store.queue_free()
-	
-	func test_patch_deleted_value():
-		# NOTE: Firebase Realtime Database sets values to null to indicate that they have been
-		#  deleted.
-		
-		var store = TestUtils.instantiate(FirebaseDatabaseStore)
-		
-		store.put(TestKey, TestObject)
-		store.patch(TestKey + "/II", null)
-		
-		var store_data: Dictionary = store.get_data()
-		var store_object = store_data[TestKey]
-		
-		assert_false(store_object.has("II"), "The value should have been deleted, but was not.")
-		
-		store.queue_free()
+    extends "res://addons/gut/test.gd"
+    
+    func test_patch_object():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.patch(TestKey, TestObject)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]
+        
+        assert_eq_deep(store_object, TestObject)
+        
+        store.queue_free()
+    
+    func test_patch_nested_object():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        store.patch(TestKey + "/V", TestObjectOther)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["V"]
+        
+        assert_eq_deep(store_object, TestObjectOther)
+        
+        store.queue_free()
+    
+    func test_patch_array_value():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        store.patch(TestKey + "/III", TestArray)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["III"]
+        
+        assert_eq_deep(store_object, TestArray)
+        
+        store.queue_free()
+    
+    func test_patch_normal_value():
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        store.patch(TestKey + "/II", TestValue)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]["II"]
+        
+        assert_eq_deep(store_object, TestValue)
+        
+        store.queue_free()
+    
+    func test_patch_deleted_value():
+        # NOTE: Firebase Realtime Database sets values to null to indicate that they have been
+        #  deleted.
+        
+        var store = TestUtils.instantiate(FirebaseDatabaseStore)
+        
+        store.put(TestKey, TestObject)
+        store.patch(TestKey + "/II", null)
+        
+        var store_data: Dictionary = store.get_data()
+        var store_object = store_data[TestKey]
+        
+        assert_false(store_object.has("II"), "The value should have been deleted, but was not.")
+        
+        store.queue_free()

--- a/test/unit/test_FirestoreDocument.gd
+++ b/test/unit/test_FirestoreDocument.gd
@@ -1,0 +1,82 @@
+extends "res://addons/gut/test.gd"
+
+const FirestoreDocument = preload("res://addons/godot-firebase/firestore/firestore_document.gd")
+
+class TestDeserialization:
+    extends "res://addons/gut/test.gd"
+    
+    func test_deserialize_array_of_dicts():
+        var doc_infos : Dictionary = {
+            "name":"projects/godot-firebase/databases/(default)/documents/rooms/EUZT",
+            "fields": {
+                "code": {
+                    "stringValue":"EUZT"
+                },
+                "players": {
+                    "arrayValue": {
+                        "values": [{
+                            "mapValue": {
+                                "fields": {
+                                    "name": {
+                                        "stringValue":"Hello"
+                                    }
+                                }
+                            }
+                        }, {
+                            "mapValue":{
+                                "fields":{
+                                    "name":{
+                                        "stringValue":"Test"
+                                    }
+                                }
+                            }
+                        }]
+                    }
+                },
+            },
+            "createTime":"2021-02-16T07:24:11.106522Z",
+            "updateTime":"2021-02-16T08:21:32.131028Z"
+        }
+        var expected_doc_fields : Dictionary = {
+            "code": "EUZT",
+            "players": [
+                { "name": "Hello" },
+                { "name": "Test" },
+            ]
+        }
+        var firestore_document : FirestoreDocument = FirestoreDocument.new(doc_infos)
+        
+        assert_eq_deep(firestore_document.doc_fields, expected_doc_fields)
+        
+        firestore_document.queue_free()
+
+    func test_deserialize_array_of_strings():
+        
+        var doc_infos : Dictionary = {
+            "name":"projects/godot-firebase/databases/(default)/documents/rooms/EUZT",
+            "fields": {
+                "code": {
+                    "stringValue":"EUZT"
+                }, 
+                "things": {
+                    "arrayValue": {
+                        "values": [{
+                            "stringValue": "first"
+                        }, {
+                            "stringValue":"second"
+                        }]
+                    }
+                }
+            },
+            "createTime":"2021-02-16T07:24:11.106522Z",
+            "updateTime":"2021-02-16T08:21:32.131028Z"
+        }
+        var expected_doc_fields : Dictionary = {
+            "code": "EUZT",
+            "things": ["first", "second"]
+        }
+        var firestore_document : FirestoreDocument = FirestoreDocument.new(doc_infos)
+        
+        assert_eq_deep(firestore_document.doc_fields, expected_doc_fields)
+        
+        firestore_document.queue_free()


### PR DESCRIPTION
- Fix deserialization of an array with dictionaries inside of it. Fixes #131 
- Add test for FirestoreDocument to prevent regressions.
- Convert tabs to spaces in existing test file to be consistent with core plugin using spaces. 