### PR TITLE
Fix issue #161 - Firestore .get() issue

### DIFF
--- a/addons/godot-firebase/firestore/firestore.gd
+++ b/addons/godot-firebase/firestore/firestore.gd
@@ -23,8 +23,7 @@ signal listed_documents(documents)
 ## @arg-types Array
 signal result_query(result)
 ## Emitted when a [code]list()[/code] or [code]query()[/code] request is [b]not[/b] successfully completed.
-## @arg-types Dictionary
-signal error(error)
+signal error(code,status,message)
 
 enum Requests {
     NONE = -1,  ## Firestore is not processing any request.
@@ -339,8 +338,9 @@ func _on_result_query(result : Dictionary):
     emit_signal("result_query", result)
 
 
-func _on_error(error : Dictionary):
-    printerr("Firestore error: " + JSON.print(error))
+func _on_error(code : int, status : int, message : String):
+    emit_signal("error", code, status, message)
+    printerr(message)
 
 
 func _on_FirebaseAuth_login_succeeded(auth_result : Dictionary) -> void:

--- a/addons/godot-firebase/firestore/firestore_task.gd
+++ b/addons/godot-firebase/firestore/firestore_task.gd
@@ -149,10 +149,10 @@ func _on_request_completed(result : int, response_code : int, headers : PoolStri
         match action:
             Task.TASK_LIST, Task.TASK_QUERY:
                 data = bod[0].error
-                emit_signal("error", bod[0].error)
+                emit_signal("error", data.code, 0, data.message)
             _:
                 data = bod.error
-                emit_signal("error", bod.error)
+                emit_signal("error", data.code, 0, data.message)
     
     emit_signal("task_finished", data)
 


### PR DESCRIPTION
This will close #161 

There is an issue when you try to use .get() in firestore on a document that does not exist. If you also have collection connected for errors, you will crash the plugin. This is because the error function from firestore_collection is looking for three arguments, but the error function in firestore_task only passes one.

I changed the line to

`emit_signal("error", data.code, 0, data.message)`

This will satisfy the number of arguments as well as the accepted type. Need to discuss if hard coding a 0 is worth it or if we should use something else.