### PR TITLE
Firestore cleanup signals

### DIFF
--- a/addons/godot-firebase/firestore/firestore.gd
+++ b/addons/godot-firebase/firestore/firestore.gd
@@ -147,7 +147,9 @@ func query(query : FirestoreQuery) -> FirestoreTask:
     if auth:
         var firestore_task : FirestoreTask = FirestoreTask.new()
         firestore_task.connect("result_query", self, "_on_result_query")
-        firestore_task.connect("error", self, "_on_error")
+        firestore_task.connect("task_error", self, "_on_task_error")
+        firestore_task.connect("task_list_error", self, "_on_task_list_error")
+        firestore_task.connect("task_query_error", self, "_on_task_query_error")
         firestore_task.action = FirestoreTask.Task.TASK_QUERY
         var body : Dictionary = { structuredQuery = query.query }
         var url : String = _base_url + _extended_url + _query_suffix
@@ -334,7 +336,7 @@ func _on_listed_documents(listed_documents : Array):
     emit_signal("listed_documents", listed_documents)
 
 
-func _on_result_query(result : Dictionary):
+func _on_result_query(result : Array):
     emit_signal("result_query", result)
 
 
@@ -342,6 +344,17 @@ func _on_error(code : int, status : int, message : String):
     emit_signal("error", code, status, message)
     printerr(message)
 
+func _on_task_error(code : int, status : String, message : String):
+    emit_signal("task_error", code, status, message)
+    printerr(message)
+
+func _on_task_list_error(code : int, status : String, message : String):
+    emit_signal("task_error", code, status, message)
+    printerr(message)
+
+func _on_task_query_error(code : int, status : String, message : String):
+    emit_signal("task_error", code, status, message)
+    printerr(message)
 
 func _on_FirebaseAuth_login_succeeded(auth_result : Dictionary) -> void:
     auth = auth_result

--- a/addons/godot-firebase/firestore/firestore_collection.gd
+++ b/addons/godot-firebase/firestore/firestore_collection.gd
@@ -145,6 +145,6 @@ func _on_update_document(document : FirestoreDocument):
 func _on_delete_document():
     emit_signal("delete_document")
 
-func _on_error(code : int, status : int, message : String):
+func _on_error(code, status, message):
     emit_signal("error", code, status, message)
     printerr(message)

--- a/addons/godot-firebase/firestore/firestore_collection.gd
+++ b/addons/godot-firebase/firestore/firestore_collection.gd
@@ -104,7 +104,7 @@ func delete(document_id : String) -> FirestoreTask:
     var url = _get_request_url() + _separator + document_id.replace(" ", "%20")
     
     task.connect("delete_document", self, "_on_delete_document")
-    task.connect("task_finished", self, "_on_task_finished", [null, document_id], CONNECT_DEFERRED)
+    task.connect("task_finished", self, "_on_task_finished", [document_id], CONNECT_DEFERRED)
     _process_request(task, document_id, url)
     return task
 

--- a/addons/godot-firebase/firestore/firestore_collection.gd
+++ b/addons/godot-firebase/firestore/firestore_collection.gd
@@ -114,7 +114,7 @@ func _get_request_url() -> String:
 
 
 func _process_request(task : FirestoreTask, document_id : String, url : String, fields := "") -> void:
-    task.connect("error", self, "_on_error")
+    task.connect("task_error", self, "_on_error")
     task._url = url
     task._fields = fields
     task._headers = PoolStringArray([_AUTHORIZATION_HEADER + auth.idtoken])

--- a/addons/godot-firebase/firestore/firestore_task.gd
+++ b/addons/godot-firebase/firestore/firestore_task.gd
@@ -44,7 +44,9 @@ signal listed_documents(documents)
 signal result_query(result)
 ## Emitted when a request is [b]not[/b] successfully completed.
 ## @arg-types Dictionary
-signal error(error)
+signal task_error(error)
+signal task_query_error(error)
+signal task_list_error(error)
 
 enum Task {
     TASK_GET,       ## A GET Request Task, processing a get() request
@@ -147,12 +149,15 @@ func _on_request_completed(result : int, response_code : int, headers : PoolStri
                 emit_signal("listed_documents", data)
     else:
         match action:
-            Task.TASK_LIST, Task.TASK_QUERY:
+            Task.TASK_LIST:
                 data = bod[0].error
-                emit_signal("error", data.code, 0, data.message)
+                emit_signal("task_list_error", data.code, data.status, data.message)
+            Task.TASK_QUERY:
+                data = bod[0].error
+                emit_signal("task_query_error", data.code, data.status, data.message)
             _:
                 data = bod.error
-                emit_signal("error", data.code, 0, data.message)
+                emit_signal("task_error", data.code, data.status, data.message)
     
     emit_signal("task_finished", data)
 


### PR DESCRIPTION
This PR will change the following

- Break out the errors in Firestore tasks to a per task error
- Change the firestore.gd file to accept the different signals from the task errors
- Remove `null` from the delete document function since it was throwing a random error
- Remove the requirements for a type of data in the error code in firestore_collection

The idea is that breaking out the signals and functions will allow us to have better control over the data that is sent and not try to force it into a single function. This PR has been built so that the end user should not have to update their code at all, but the behind the scenes functions work better.

This PR will close the following:
close #166 