### PR TITLE
Fix update not queing requests

### DIFF
--- a/addons/godot-firebase/database/reference.gd
+++ b/addons/godot-firebase/database/reference.gd
@@ -97,7 +97,7 @@ func update(path : String, data : Dictionary) -> void:
         path = ""
     
     var to_update = JSON.print(data)
-    if _pusher.get_http_client_status() != HTTPClient.STATUS_REQUESTING:
+    if _pusher.get_http_client_status() == HTTPClient.STATUS_DISCONNECTED:
         var resolved_path = (_get_list_url() + _db_path + "/" + path + _get_remaining_path())
         
         _pusher.request(resolved_path, _headers, true, HTTPClient.METHOD_PATCH, to_update)


### PR DESCRIPTION
If you send an 'update request' too quickly, the expected results is to add the request to a 'queue' and do that request after the previous request is finished..... What happens is it does not add to the queue, and tries to make the request anyways, which causes the http_client to return an error about trying to make too many requests at the same time.

This resolves that issue, by checking if the http_client status is 'disconnected'.