### PR TITLE
Fix automatic creation and removal of the Firebase autoload singleton

### DIFF
--- a/addons/godot-firebase/plugin.gd
+++ b/addons/godot-firebase/plugin.gd
@@ -1,8 +1,8 @@
 tool
 extends EditorPlugin
 
-func _enter_tree() -> void:
-    add_autoload_singleton("Firebase", "res://addons/godot-firebase/firebase/firebase.tscn")
-
-func _exit_tree() -> void:
+func disable_plugin() -> void:
     remove_autoload_singleton("Firebase")
+
+func enable_plugin() -> void:
+    add_autoload_singleton("Firebase", "res://addons/godot-firebase/firebase/firebase.tscn")


### PR DESCRIPTION
Automatic creation and deletion of the Firebase autoload singleton should not be done on every Godot engine restart; instead, it should be done whenever the plugin is enabled or disabled, which this fix does.

I've tested that ```_exit_tree()``` of [plugin.gd](https://github.com/GodotNuts/GodotFirebase/blob/godotfirebase-v4.2/addons/godot-firebase/plugin.gd) will always fire when the Godot engine is exited. However, ```remove_autoload_singleton()``` does not always fire, which causes some unexpected behavior leading to #270 and https://github.com/AlexDarigan/WAT/issues/314. Ultimately, the singleton should be created when the plugin is enabled, and cleaned up when it is disabled, not on every restart which can interfere with the user's Autoload order.