### PR TITLE
Dot notation

### DIFF
--- a/addons/godot-firebase/firestore/firestore_document.gd
+++ b/addons/godot-firebase/firestore/firestore_document.gd
@@ -25,18 +25,26 @@ func _init(doc : Dictionary = {}, _doc_name : String = "", _doc_fields : Diction
     self.create_time = doc.createTime
 
 # Pass a dictionary { 'key' : 'value' } to format it in a APIs usable .fields 
+# Field Path using the "dot" (`.`) notation are supported: 
+# ex. { "PATH.TO.SUBKEY" : "VALUE" } ==> { "PATH" : { "TO" : { "SUBKEY" : "VALUE" } } }
 static func dict2fields(dict : Dictionary) -> Dictionary:
     var fields : Dictionary = {}
     var var_type : String = ""
     for field in dict.keys():
         var field_value = dict[field]
-        match typeof(dict[field]):
+        if "." in field:
+            var keys: Array = field.split(".")
+            field = keys.pop_front()
+            keys.invert()
+            for key in keys:
+                field_value = { key : field_value }
+        match typeof(field_value):
             TYPE_NIL: var_type = "nullValue"
             TYPE_BOOL: var_type = "booleanValue"
             TYPE_INT: var_type = "integerValue"
             TYPE_REAL: var_type = "doubleValue"
             TYPE_STRING: var_type = "stringValue"
-            TYPE_DICTIONARY: 
+            TYPE_DICTIONARY:
                 if is_field_timestamp(field_value):
                     var_type = "timestampValue"
                     field_value = dict2timestamp(field_value)


### PR DESCRIPTION
A recursive algorithm has been added in order to support direct referencing of subkeys i complex paths
For example
```
# Document A

"FIRST_LEVEL"
├─ "SECOND_LEVEL_1" : "VALUE_1"
└─ "SECOND_LEVEL_2" : "VALUE_2"
```
`SECOND_LEVEL_1` value can now be updated without overwriting the whole document, in this way:
```gdscript
Firebase.Firestore.collection("...").update("<document>", { "FIRST_LEVEL.SECOND_LEVEL_1":"VALUE_1" }})
```