### PR TITLE
Fix: Parameters not being passed to Firebase using GET method

### DIFF
--- a/addons/godot-firebase/functions/functions.gd
+++ b/addons/godot-firebase/functions/functions.gd
@@ -75,12 +75,13 @@ func execute(function: String, method: int, params: Dictionary = {}, body: Dicti
     function_task._method = method
 
     var url : String = _base_url + ("/" if not _base_url.ends_with("/") else "") + function
-    function_task._url = url
 
     if not params.empty():
         url += "?"
         for key in params.keys():
             url += key + "=" + params[key] + "&"
+    
+    function_task._url = url
 
     if not body.empty():
         function_task._headers = PoolStringArray(["Content-Type: application/json"])


### PR DESCRIPTION
As requested on the issues page, here is a simple PR to fix the missing GET parameters for Functions