### PR TITLE
Fixes an issue with HTTPRequest on web exports

### DIFF
--- a/addons/godot-firebase/Utilies.gd
+++ b/addons/godot-firebase/Utilies.gd
@@ -10,3 +10,11 @@ static func get_json_data(value):
         return json.data
     
     return null
+
+
+# HTTPRequeust seems to have an issue in Web exports where the body returns empty
+# This appears to be caused by the gzip compression being unsupported, so we
+# disable it when web export is detected.
+static func fix_http_request(http_request):
+    if OS.get_name() == "HTML5" or OS.get_name() == "Web":
+        http_request.accept_gzip = false

--- a/addons/godot-firebase/auth/auth.gd
+++ b/addons/godot-firebase/auth/auth.gd
@@ -147,7 +147,8 @@ func _ready() -> void:
     tcp_timer.wait_time = tcp_timeout
     tcp_timer.timeout.connect(_tcp_stream_timer)
     
-    if OS.get_name() == "HTML5":
+    if OS.get_name() == "HTML5" or OS.get_name() == "Web":
+        accept_gzip = false # Fixes broken gzip compression in web exports
         _local_uri += "tmp_js_export.html"
 
 

--- a/addons/godot-firebase/auth/auth.gd
+++ b/addons/godot-firebase/auth/auth.gd
@@ -147,8 +147,8 @@ func _ready() -> void:
     tcp_timer.wait_time = tcp_timeout
     tcp_timer.timeout.connect(_tcp_stream_timer)
     
+    Utilities.fix_http_request(self)
     if OS.get_name() == "HTML5" or OS.get_name() == "Web":
-        accept_gzip = false # Fixes broken gzip compression in web exports
         _local_uri += "tmp_js_export.html"
 
 

--- a/addons/godot-firebase/database/database.gd
+++ b/addons/godot-firebase/database/database.gd
@@ -42,8 +42,7 @@ func _on_FirebaseAuth_logout() -> void:
 func get_database_reference(path : String, filter : Dictionary = {}) -> FirebaseDatabaseReference:
     var firebase_reference : FirebaseDatabaseReference = FirebaseDatabaseReference.new()
     var pusher : HTTPRequest = HTTPRequest.new()
-    if OS.get_name() == "HTML5" or OS.get_name() == "Web":
-        pusher.accept_gzip = false # Fixes broken gzip compression in web exports
+    Utilities.fix_http_request(pusher)
     pusher.use_threads = true
     var listener : Node = Node.new()
     listener.set_script(load("res://addons/http-sse-client/HTTPSSEClient.gd"))

--- a/addons/godot-firebase/database/database.gd
+++ b/addons/godot-firebase/database/database.gd
@@ -42,6 +42,8 @@ func _on_FirebaseAuth_logout() -> void:
 func get_database_reference(path : String, filter : Dictionary = {}) -> FirebaseDatabaseReference:
     var firebase_reference : FirebaseDatabaseReference = FirebaseDatabaseReference.new()
     var pusher : HTTPRequest = HTTPRequest.new()
+    if OS.get_name() == "HTML5" or OS.get_name() == "Web":
+        pusher.accept_gzip = false # Fixes broken gzip compression in web exports
     pusher.use_threads = true
     var listener : Node = Node.new()
     listener.set_script(load("res://addons/http-sse-client/HTTPSSEClient.gd"))

--- a/addons/godot-firebase/dynamiclinks/dynamiclinks.gd
+++ b/addons/godot-firebase/dynamiclinks/dynamiclinks.gd
@@ -33,7 +33,7 @@ func _set_config(config_json : Dictionary) -> void:
     _config = config_json
     _request_list_node = HTTPRequest.new()
     if OS.get_name() == "HTML5" or OS.get_name() == "Web":
-        _request_list_node .accept_gzip = false # Fixes broken gzip compression in web exports
+        _request_list_node.accept_gzip = false # Fixes broken gzip compression in web exports
     _request_list_node.request_completed.connect(_on_request_completed)
     add_child(_request_list_node)
     _check_emulating()

--- a/addons/godot-firebase/dynamiclinks/dynamiclinks.gd
+++ b/addons/godot-firebase/dynamiclinks/dynamiclinks.gd
@@ -32,8 +32,7 @@ enum Requests {
 func _set_config(config_json : Dictionary) -> void:
     _config = config_json
     _request_list_node = HTTPRequest.new()
-    if OS.get_name() == "HTML5" or OS.get_name() == "Web":
-        _request_list_node.accept_gzip = false # Fixes broken gzip compression in web exports
+    Utilities.fix_http_request(_request_list_node)
     _request_list_node.request_completed.connect(_on_request_completed)
     add_child(_request_list_node)
     _check_emulating()

--- a/addons/godot-firebase/dynamiclinks/dynamiclinks.gd
+++ b/addons/godot-firebase/dynamiclinks/dynamiclinks.gd
@@ -32,6 +32,8 @@ enum Requests {
 func _set_config(config_json : Dictionary) -> void:
     _config = config_json
     _request_list_node = HTTPRequest.new()
+    if OS.get_name() == "HTML5" or OS.get_name() == "Web":
+        _request_list_node .accept_gzip = false # Fixes broken gzip compression in web exports
     _request_list_node.request_completed.connect(_on_request_completed)
     add_child(_request_list_node)
     _check_emulating()

--- a/addons/godot-firebase/firestore/firestore.gd
+++ b/addons/godot-firebase/firestore/firestore.gd
@@ -264,8 +264,7 @@ func _pooled_request(task : FirestoreTask) -> void:
     if not http_request:
         http_request = HTTPRequest.new()
         http_request.timeout = 5
-        if OS.get_name() == "HTML5" or OS.get_name() == "Web":
-            http_request.accept_gzip = false # Fixes broken gzip compression in web exports
+        Utilities.fix_http_request(http_request)
         _http_request_pool.append(http_request)
         add_child(http_request)
         http_request.request_completed.connect(_on_pooled_request_completed.bind(http_request))

--- a/addons/godot-firebase/firestore/firestore.gd
+++ b/addons/godot-firebase/firestore/firestore.gd
@@ -264,6 +264,8 @@ func _pooled_request(task : FirestoreTask) -> void:
     if not http_request:
         http_request = HTTPRequest.new()
         http_request.timeout = 5
+        if OS.get_name() == "HTML5" or OS.get_name() == "Web":
+            http_request.accept_gzip = false # Fixes broken gzip compression in web exports
         _http_request_pool.append(http_request)
         add_child(http_request)
         http_request.request_completed.connect(_on_pooled_request_completed.bind(http_request))

--- a/addons/godot-firebase/functions/functions.gd
+++ b/addons/godot-firebase/functions/functions.gd
@@ -168,6 +168,8 @@ func _pooled_request(task : FunctionTask) -> void:
 
     if not http_request:
         http_request = HTTPRequest.new()
+        if OS.get_name() == "HTML5" or OS.get_name() == "Web":
+            http_request.accept_gzip = false # Fixes broken gzip compression in web exports
         _http_request_pool.append(http_request)
         add_child(http_request)
         http_request.request_completed.connect(_on_pooled_request_completed.bind(http_request))

--- a/addons/godot-firebase/functions/functions.gd
+++ b/addons/godot-firebase/functions/functions.gd
@@ -168,8 +168,7 @@ func _pooled_request(task : FunctionTask) -> void:
 
     if not http_request:
         http_request = HTTPRequest.new()
-        if OS.get_name() == "HTML5" or OS.get_name() == "Web":
-            http_request.accept_gzip = false # Fixes broken gzip compression in web exports
+        Utilities.fix_http_request(http_request)
         _http_request_pool.append(http_request)
         add_child(http_request)
         http_request.request_completed.connect(_on_pooled_request_completed.bind(http_request))


### PR DESCRIPTION
* disable gzip compression on web export, as this results in HTTPRequest returning an empty body due to a failure in decompression
* also check for "Web" in OS.get_name() ("HTML5" appears to be an old value)