### PR TITLE
Redirect to correct local port after OAuth2 success

### DIFF
--- a/addons/godot-firebase/auth/auth.gd
+++ b/addons/godot-firebase/auth/auth.gd
@@ -135,10 +135,13 @@ var _update_profile_body: Dictionary = {
     "returnSecureToken": true,
 }
 
-var _local_port: int = 8060
+var _local_port: int = 8060 setget _set_local_port
 var _local_uri: String = "http://localhost:%s/" % _local_port
 var _local_provider: AuthProvider = AuthProvider.new()
 
+func _set_local_port(value: int) -> void:
+    _local_port = value
+    _local_uri = "http://localhost:%s" % _local_port
 
 func _ready() -> void:
     tcp_timer.wait_time = tcp_timeout
@@ -251,6 +254,7 @@ func login_with_custom_token(token: String) -> void:
 # Once given user's authorization, a token will be generated.
 # NOTE** the generated token will be automatically captured and a login request will be made if the token is correct
 func get_auth_localhost(provider: AuthProvider = get_GoogleProvider(), port: int = _local_port):
+    _set_local_port(port)
     get_auth_with_redirect(provider)
     yield(get_tree().create_timer(0.5),"timeout")
     if has_child == false:


### PR DESCRIPTION
The redirect_uri param always defaulted to http://localhost:8060 even when using a port other than default on function call get_auth_localhost.

**The relevant issue number, if applicable.**
No issue has been opened.

**Any new features that have been added**
Added a setter to _local_port to re-create the _local_uri var according to the port specified.

**Any relevant tests that have been run**
No relevant test have been run or written