### PR TITLE
Fix #349 FirestoreQuery.select with array as parameter results in 400

### DIFF
--- a/addons/godot-firebase/firestore/firestore_query.gd
+++ b/addons/godot-firebase/firestore/firestore_query.gd
@@ -75,9 +75,11 @@ func select(fields) -> FirestoreQuery:
         TYPE_STRING:
             query["select"] = { fields = { fieldPath = fields } }
         TYPE_ARRAY:
+            var local_fields = []
             for field in fields:
                 field = ({ fieldPath = field })
-            query["select"] = { fields = fields }
+                local_fields.append(field)
+            query["select"] = { fields = local_fields }
         _:
             print("Type of 'fields' is not accepted.")
     return self


### PR DESCRIPTION
String values seem to be passed by value rather than reference even though arrays are passed by reference. Added a local array and re-populated it to fix

The relevant issue number, if applicable.
#349 

Any new features that have been added
-

Any relevant tests that have been run
Manually tested for expected behavior
No relevant test have been run or written