### PR TITLE
Prevent hanging await and return relative value

### DIFF
--- a/addons/godot-firebase/firestore/firestore_task.gd
+++ b/addons/godot-firebase/firestore/firestore_task.gd
@@ -24,22 +24,22 @@ extends RefCounted
 ## Emitted when a request is completed. The request can be successful or not successful: if not, an [code]error[/code] Dictionary will be passed as a result.
 ## @arg-types Variant
 signal task_finished(task)
-## Emitted when a [code]add(document)[/code] request checked a [class FirebaseCollection] is successfully completed. [code]error()[/code] signal will be emitted otherwise.
+## Emitted when a [code]add(document)[/code] request checked a [class FirebaseCollection] is successfully completed. [code]error()[/code] signal will be emitted otherwise and [code]null[/code] will be passed as a result..
 ## @arg-types FirestoreDocument
 signal add_document(doc)
-## Emitted when a [code]get(document)[/code] request checked a [class FirebaseCollection] is successfully completed. [code]error()[/code] signal will be emitted otherwise.
+## Emitted when a [code]get(document)[/code] request checked a [class FirebaseCollection] is successfully completed. [code]error()[/code] signal will be emitted otherwise and [code]null[/code] will be passed as a result.
 ## @arg-types FirestoreDocument
 signal get_document(doc)
-## Emitted when a [code]update(document)[/code] request checked a [class FirebaseCollection] is successfully completed. [code]error()[/code] signal will be emitted otherwise.
+## Emitted when a [code]update(document)[/code] request checked a [class FirebaseCollection] is successfully completed. [code]error()[/code] signal will be emitted otherwise and [code]null[/code] will be passed as a result.
 ## @arg-types FirestoreDocument
 signal update_document(doc)
-## Emitted when a [code]delete(document)[/code] request checked a [class FirebaseCollection] is successfully completed. [code]error()[/code] signal will be emitted otherwise.
-## @arg-types FirestoreDocument
-signal delete_document()
-## Emitted when a [code]list(collection_id)[/code] request checked [class FirebaseFirestore] is successfully completed. [code]error()[/code] signal will be emitted otherwise.
+## Emitted when a [code]delete(document)[/code] request checked a [class FirebaseCollection] is successfully completed and [code]true[/code] will be passed. [code]error()[/code] signal will be emitted otherwise and [code]false[/code] will be passed as a result.
+## @arg-types bool
+signal delete_document(success)
+## Emitted when a [code]list(collection_id)[/code] request checked [class FirebaseFirestore] is successfully completed. [code]error()[/code] signal will be emitted otherwise and [code][][/code] will be passed as a result..
 ## @arg-types Array
 signal listed_documents(documents)
-## Emitted when a [code]query(collection_id)[/code] request checked [class FirebaseFirestore] is successfully completed. [code]error()[/code] signal will be emitted otherwise.
+## Emitted when a [code]query(collection_id)[/code] request checked [class FirebaseFirestore] is successfully completed. [code]error()[/code] signal will be emitted otherwise and [code][][/code] will be passed as a result.
 ## @arg-types Array
 signal result_query(result)
 ## Emitted when a request is [b]not[/b] successfully completed.
@@ -98,7 +98,7 @@ func _on_request_completed(result : int, response_code : int, headers : PackedSt
                 document = FirestoreDocument.new(bod)
                 update_document.emit(document)
             Task.TASK_DELETE:
-                delete_document.emit()
+                delete_document.emit(true)
             Task.TASK_QUERY:
                 data = []
                 for doc in bod:
@@ -116,6 +116,21 @@ func _on_request_completed(result : int, response_code : int, headers : PackedSt
     else:
         Firebase._printerr("Action in error was: " + str(action))
         emit_error(task_error, bod, action)
+        match action:
+            Task.TASK_POST:
+                add_document.emit(null)
+            Task.TASK_GET:
+                get_document.emit(null)
+            Task.TASK_PATCH:
+                update_document.emit(null)
+            Task.TASK_DELETE:
+                delete_document.emit(false)
+            Task.TASK_QUERY:
+                data = []
+                result_query.emit(data)
+            Task.TASK_LIST:
+                data = []
+                listed_documents.emit(data)
 
     task_finished.emit(self)
 


### PR DESCRIPTION
I found a potential issue for a hanging await. He is my example code which should help explain things:
```
func check_if_doc_exists(player_name) -> int:
    var document_task = scores_collection.get_doc(player_name)
    var document = await document_task.get_document
    if document != null:
        return document.doc_fields.score
    return 0
```

In the code above, if the `get_doc` emits a `task_error` signal the `await document_task.get_document` will never return and I think it just hangs there. 

One way to solve this currently is to use `await document_task.task_finished` instead but that seems a bit confusing to newcomers to the library like myself. To me, it makes sense to await the expected signal and check if the returned value is correct or not. Returning a null or empty array on error seems like a good value to return, which can also be easily handled. 

On delete document I see the library isn't returning anything here but this could create the same hanging await issue. So I thought of returning a success bool whether it was successful or not. Allowing me to handle errors more easily in the code. 

Let me know if this sounds like a good idea. Thanks 