### PR TITLE
Fix for #372 delete_document error

### DIFF
--- a/addons/godot-firebase/firestore/firestore_collection.gd
+++ b/addons/godot-firebase/firestore/firestore_collection.gd
@@ -136,8 +136,8 @@ func _on_add_document(document : FirestoreDocument):
 func _on_update_document(document : FirestoreDocument):
     emit_signal("update_document", document )
 
-func _on_delete_document():
-    emit_signal("delete_document")
+func _on_delete_document(success: bool):
+    emit_signal("delete_document", success)
 
 func _on_error(code, status, message, task):
     emit_signal("error", code, status, message)


### PR DESCRIPTION
Fixed by adding a bool parameter to the _on_delete_document function in firestore_collection.gd