### PR TITLE
Fix #379: Replaced "JavaScript" feature tag.

### DIFF
--- a/addons/godot-firebase/auth/auth.gd
+++ b/addons/godot-firebase/auth/auth.gd
@@ -146,7 +146,7 @@ var _local_provider : AuthProvider = AuthProvider.new()
 func _ready() -> void:
     tcp_timer.wait_time = tcp_timeout
     tcp_timer.timeout.connect(_tcp_stream_timer)
-    
+
     Utilities.fix_http_request(self)
     if OS.get_name() == "HTML5" or OS.get_name() == "Web":
         _local_uri += "tmp_js_export.html"
@@ -281,7 +281,7 @@ func get_auth_with_redirect(provider: AuthProvider) -> void:
         url_endpoint+=key+"="+provider.params[key]+"&"
     url_endpoint += provider.params.redirect_type+"="+_local_uri
     url_endpoint = _clean_url(url_endpoint)
-    if OS.get_name() == "HTML5" and OS.has_feature("JavaScript"):
+    if OS.get_name() == "HTML5" and OS.has_feature("web"):
         JavaScriptBridge.eval('window.location.replace("' + url_endpoint + '")')
     elif Engine.has_singleton(_INAPP_PLUGIN) and OS.get_name() == "iOS":
         #in app for ios if the iOS plugin exists
@@ -334,7 +334,7 @@ func exchange_token(code : String, redirect_uri : String, request_url: String, _
         if err != OK:
             is_busy = false
             Firebase._printerr("Error exchanging tokens: %s" % err)
-            
+
 # Open a web page in browser redirecting to Google oAuth2 page for the current project
 # Once given user's authorization, a token will be generated.
 # NOTE** with this method, the authorization process will be copy-pasted
@@ -357,13 +357,13 @@ func _tcp_stream_timer() -> void:
                 if _local_provider.params.response_type in splitted[0]:
                     token = splitted[1]
                     break
-                    
+
             if token == "":
                 login_failed.emit()
                 peer.disconnect_from_host()
                 tcp_server.stop()
                 return
-                
+
             var data : PackedByteArray = '<p style="text-align:center">&#128293; You can close this window now. &#128293;</p>'.to_ascii_buffer()
             peer.put_data(("HTTP/1.1 200 OK\n").to_ascii_buffer())
             peer.put_data(("Server: Godot Firebase SDK\n").to_ascii_buffer())
@@ -375,7 +375,7 @@ func _tcp_stream_timer() -> void:
             await self.login_succeeded
             peer.disconnect_from_host()
             tcp_server.stop()
-            
+
 
 # Function used to logout of the system, this will also remove_at the local encrypted auth file if there is one
 func logout() -> void:
@@ -419,7 +419,7 @@ func _on_FirebaseAuth_request_completed(result : int, response_code : int, heade
             Firebase._printerr("Error while parsing auth body json")
             auth_request.emit(ERR_PARSE_ERROR, "Error while parsing auth body json")
             return
-        
+
         res = json
 
     if response_code == HTTPClient.RESPONSE_OK:
@@ -619,8 +619,8 @@ func begin_refresh_countdown() -> void:
 
 func get_token_from_url(provider: AuthProvider):
     var token_type: String = provider.params.response_type if provider.params.response_type == "code" else "access_token"
-    if OS.has_feature('JavaScript'):
-        var token = JavaScriptBridge.eval(""" 
+    if OS.has_feature('web'):
+        var token = JavaScriptBridge.eval("""
             var url_string = window.location.href.replaceAll('?#', '?');
             var url = new URL(url_string);
             url.searchParams.get('"""+token_type+"""');


### PR DESCRIPTION
Replaced `OS.has_feature('JavaScript')` with` OS.has_feature('web')`, as the JavaScript feature tag is removed for Godot 4.

Solves the issue #379 

According to Godot documentation : [Feature tags](https://docs.godotengine.org/en/4.2/tutorials/export/feature_tags.html) and [Example](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_web.html#calling-javascript-from-script)