### PR TITLE
[Godot 4] Storage paths can now have space characters

### DIFF
--- a/addons/godot-firebase/storage/storage.gd
+++ b/addons/godot-firebase/storage/storage.gd
@@ -325,7 +325,7 @@ func _finish_request(result : int) -> void:
 func _get_file_url(ref : StorageReference) -> String:
     var url := _extended_url.replace("[APP_ID]", ref.bucket)
     url = url.replace("[API_VERSION]", _API_VERSION)
-    return url.replace("[FILE_PATH]", ref.full_path.replace("/", "%2F"))
+    return url.replace("[FILE_PATH]", ref.full_path.uri_encode())
 
 # Removes any "../" or "./" in the file path.
 func _simplify_path(path : String) -> String:


### PR DESCRIPTION
Same as #387, but for the `4.0` branch.


I was trying to create a new file in the Firebase Storage with space characters in the file name, e.g:

```gdscript
Firebase.Storage.ref("path with space/image.png").put_file("res://image.png")
```

But it would fail, even if Firebase allows paths to have spaces. Turns out it was because the space character wasn't being encoded in the url parameter, only the forward slash `/` was.

Using the `uri_encode()`, it should encode both the slash and space characters, as well as any other character.
