### PR TITLE
Add arrayValue conversion to from_firebase_type

### DIFF
--- a/addons/godot-firebase/Utilities.gd
+++ b/addons/godot-firebase/Utilities.gd
@@ -58,6 +58,8 @@ static func from_firebase_type(value : Variant) -> Variant:
 	
 	if value.has("mapValue"):
 		value = fields2dict(value.values()[0])
+	elif value.has("arrayValue"):
+		value = fields2array(value.values()[0])
 	elif value.has("timestampValue"):
 		value = Time.get_datetime_dict_from_datetime_string(value.values()[0], false)
 	else:


### PR DESCRIPTION
While experimenting with retrieving data from Firebase, I encountered an issue where a value wasn't being converted to an Array.  This PR adds a fields2array conversion for arrayValue types, assuming there isn't a reason it was excluded—happy to be educated if so!

Tested by making the change to the local copy of this plugin in my project and can confirm that it converts the { "arrayValue" : { ... } } to an array as expected.