### PR TITLE
Update firestore_query.gd, select() method fixed for array of strings

### DIFF
--- a/addons/godot-firebase/firestore/firestore_query.gd
+++ b/addons/godot-firebase/firestore/firestore_query.gd
@@ -73,11 +73,12 @@ func _init():
 func select(fields) -> FirestoreQuery:
 	match typeof(fields):
 		TYPE_STRING:
-			query["select"] = { fields = { fieldPath = fields } }
+			query["select"] = { "fields": [{ "fieldPath": fields }] }
 		TYPE_ARRAY:
+			var field_list = []
 			for field in fields:
-				field = ({ fieldPath = field })
-			query["select"] = { fields = fields }
+				field_list.append({ "fieldPath": field })
+			query["select"] = { "fields": field_list }
 		_:
 			print("Type of 'fields' is not accepted.")
 	return self


### PR DESCRIPTION
Passing array of strings resulted in 400 error.
```
400
Invalid value at 'structured_query.select.fields[0]' (type.googleapis.com/google.firestore.v1.StructuredQuery.FieldReference), "total_score"
Invalid value at 'structured_query.select.fields[1]' (type.googleapis.com/google.firestore.v1.StructuredQuery.FieldReference), "username"
```
This change fixes the error.