### PR TITLE
fix: timestamp error add to 'Z'

### DIFF
--- a/addons/godot-firebase/Utilities.gd
+++ b/addons/godot-firebase/Utilities.gd
@@ -214,7 +214,7 @@ static func dict2timestamp(dict : Dictionary) -> String:
 	#dict.erase('dst')
 	#var dict_values : Array = dict.values()
 	var time = Time.get_datetime_string_from_datetime_dict(dict, false)
-	return time
+	return time + "Z"
 	#return "%04d-%02d-%02dT%02d:%02d:%02d.00Z" % dict_values
 
 # Converts a Firebase Timestamp back to a gdscript Dictionary


### PR DESCRIPTION
Fixed a bug where Firestore timestampValue was not being correctly recognized because the Z (Zulu/UTC) suffix was missing from the end of the ISO 8601 string.